### PR TITLE
Update wp-content import to implement batch-wise processing

### DIFF
--- a/azure_app_service_migration/admin/engines/class-azure_app_service_migration-export.php
+++ b/azure_app_service_migration/admin/engines/class-azure_app_service_migration-export.php
@@ -1,0 +1,103 @@
+<?php
+class Azure_app_service_migration_Export {
+
+    public static function export($params) {
+
+		// Continue execution when user aborts
+		@ignore_user_abort( true );
+
+		// Set maximum execution time
+		@set_time_limit( 0 );
+
+		// Set maximum time in seconds a script is allowed to parse input data
+		@ini_set( 'max_input_time', '-1' );
+
+		// Set maximum backtracking steps
+		@ini_set( 'pcre.backtrack_limit', PHP_INT_MAX );
+
+		// Set params
+		if ( empty( $params ) ) {
+			$params = stripslashes_deep( array_merge( $_GET, $_POST ) );
+		}
+
+		// Set priority
+		if ( ! isset( $params['priority'] ) ) {
+			$params['priority'] = 5;
+		}
+		
+		// First time functions executed here
+		if ( isset($params['is_first_request']) && $params['is_first_request']) {
+			// initalize import log file
+			Azure_app_service_migration_Custom_Logger::delete_log_file(AASM_EXPORT_SERVICE_TYPE);			
+			Azure_app_service_migration_Custom_Logger::init(AASM_EXPORT_SERVICE_TYPE);
+			Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Started with the export process.');
+			
+			$params['password'] = isset($_REQUEST['confpassword']) ? $_REQUEST['confpassword'] : "";
+			$params['dontexptpostrevisions'] = isset($_REQUEST['dontexptpostrevisions']) ? $_REQUEST['dontexptpostrevisions'] : "";
+			$params['dontexptsmedialibrary'] = isset($_REQUEST['dontexptsmedialibrary']) ? $_REQUEST['dontexptsmedialibrary'] : "";
+			$params['dontexptsthems'] = isset($_REQUEST['dontexptsthems']) ? $_REQUEST['dontexptsthems'] : "";
+			$params['dontexptmustuseplugins'] = isset($_REQUEST['dontexptmustuseplugs']) ? $_REQUEST['dontexptmustuseplugs'] : "";
+			$params['dontexptplugins'] = isset($_REQUEST['dontexptplugins']) ? $_REQUEST['dontexptplugins'] : "";
+			$params['dontdbsql'] = isset($_REQUEST['donotdbsql']) ? $_REQUEST['donotdbsql'] : "";
+
+			// delete enumerate csv file
+			if (file_exists(AASM_EXPORT_ENUMERATE_FILE)) {
+				Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Deleting the previously generated enumerate csv file.');
+				unlink(AASM_EXPORT_ENUMERATE_FILE);
+			}
+
+			Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Deleting the previously generated exported file.');
+			Azure_app_service_migration_Export_FileBackupHandler::deleteExistingZipFiles();
+
+			Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Deleting existing database sql files.');
+			AASM_Common_Utils::clear_directory_recursive(AASM_DATABASE_SQL_DIR);
+
+			// generate zip file name
+			$params['zip_file_name'] = Azure_app_service_migration_Export_FileBackupHandler::generateZipFileName();
+			Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Zip file name is generated as: ' . $zipFileName);
+			
+			// clear is_first_request param
+			unset($params['is_first_request']);
+		}
+
+		$params['completed'] = false;
+
+		// Loop over filters
+		if ( ( $filters = AASM_Common_Utils::get_filter_callbacks( 'aasm_export' ) ) ) {
+			while ( $hooks = current( $filters ) ) {
+				if ( intval( $params['priority'] ) === key( $filters ) ) {
+					foreach ( $hooks as $hook ) {
+						try {
+							// Run function hook
+							$params = call_user_func_array( $hook['function'], array( $params ) );
+						} catch ( Exception $e ) {
+							Azure_app_service_migration_Custom_Logger::handleException($e);
+							exit;
+						}
+					}
+
+					// exit after export process is completed
+					if ($params['completed']) {
+						Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Export successfully completed.', true);
+						exit;
+					}
+
+					$response = wp_remote_post(                                                                                                        
+						admin_url( 'admin-ajax.php?action=export' ) ,
+						array(                                               
+						'method'    => 'POST',
+						'timeout'   => 5,                                        
+						'blocking'  => false,
+						'sslverify' => false,
+						'headers'   => AASM_Common_Utils::http_export_headers(array()),                                             
+						'body'      => $params,
+						'cookies'   => array(),
+						)                                           
+					);
+					exit;
+				}
+				next( $filters );
+			}
+		}		
+    }
+}

--- a/azure_app_service_migration/admin/engines/class-azure_app_service_migration-export.php
+++ b/azure_app_service_migration/admin/engines/class-azure_app_service_migration-export.php
@@ -30,8 +30,8 @@ class Azure_app_service_migration_Export {
 			// initalize import log file
 			Azure_app_service_migration_Custom_Logger::delete_log_file(AASM_EXPORT_SERVICE_TYPE);			
 			Azure_app_service_migration_Custom_Logger::init(AASM_EXPORT_SERVICE_TYPE);
-			Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Started with the export process.');
-			
+			Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Starting Export.');
+
 			$params['password'] = isset($_REQUEST['confpassword']) ? $_REQUEST['confpassword'] : "";
 			$params['dontexptpostrevisions'] = isset($_REQUEST['dontexptpostrevisions']) ? $_REQUEST['dontexptpostrevisions'] : "";
 			$params['dontexptsmedialibrary'] = isset($_REQUEST['dontexptsmedialibrary']) ? $_REQUEST['dontexptsmedialibrary'] : "";
@@ -45,6 +45,9 @@ class Azure_app_service_migration_Export {
 				Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Deleting the previously generated enumerate csv file.');
 				unlink(AASM_EXPORT_ENUMERATE_FILE);
 			}
+
+			//initialize status file
+			AASM_Common_Utils::initialize_status_file(AASM_EXPORT_SERVICE_TYPE);
 
 			Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Deleting the previously generated exported file.');
 			Azure_app_service_migration_Export_FileBackupHandler::deleteExistingZipFiles();
@@ -78,7 +81,7 @@ class Azure_app_service_migration_Export {
 
 					// exit after export process is completed
 					if ($params['completed']) {
-						Azure_app_service_migration_Custom_Logger::logInfo(AASM_EXPORT_SERVICE_TYPE, 'Export successfully completed.', true);
+						Azure_app_service_migration_Custom_Logger::done(AASM_EXPORT_SERVICE_TYPE);
 						exit;
 					}
 

--- a/azure_app_service_migration/admin/engines/class-azure_app_service_migration-import-controller.php
+++ b/azure_app_service_migration/admin/engines/class-azure_app_service_migration-import-controller.php
@@ -24,11 +24,19 @@ class Azure_app_service_migration_Import_Controller {
 		if ( ! isset( $params['priority'] ) ) {
 			$params['priority'] = 5;
 		}
+		
+		if ( isset($params['is_first_request']) && $params['is_first_request']) {
+			// initalize import log file
+			Azure_app_service_migration_Custom_Logger::init(AASM_IMPORT_SERVICE_TYPE);
+			
+			// clear DB temp directory
+			AASM_Common_Utils::clear_directory_recursive(AASM_DATABASE_TEMP_DIR);
 
-		// Set completed flag
-		if ( ! isset( $params['completed'] ) ) {
-			$params['completed'] = false;
+			// clear is_first_request param
+			unset($params['is_first_request']);
 		}
+
+		$params['completed'] = false;
 
 		// Loop over filters
 		if ( ( $filters = AASM_Common_Utils::get_filter_callbacks( 'aasm_import' ) ) ) {
@@ -45,7 +53,7 @@ class Azure_app_service_migration_Import_Controller {
 					}
 
 					// exit after the last function of import process is completed
-					if ($params['priority'] == 10 && $params['completed']) {
+					if ($params['priority'] == 20 && $params['completed']) {
 						Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Import successfully completed.', true);
 						exit;
 					}

--- a/azure_app_service_migration/admin/engines/class-azure_app_service_migration-import-controller.php
+++ b/azure_app_service_migration/admin/engines/class-azure_app_service_migration-import-controller.php
@@ -53,7 +53,7 @@ class Azure_app_service_migration_Import_Controller {
 					}
 
 					// exit after the last function of import process is completed
-					if ($params['priority'] == 20 && $params['completed']) {
+					if ($params['priority'] == 40 && $params['completed']) {
 						Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Import successfully completed.', true);
 						exit;
 					}
@@ -79,7 +79,7 @@ class Azure_app_service_migration_Import_Controller {
 
 	public static function base_import($params) {
 		$import_file_path = AASM_IMPORT_ZIP_LOCATION . 'importfile.zip';
-
+		
 		// delete existing log file
 		Azure_app_service_migration_Custom_Logger::delete_log_file(AASM_IMPORT_SERVICE_TYPE);
         

--- a/azure_app_service_migration/admin/engines/class-azure_app_service_migration-import-controller.php
+++ b/azure_app_service_migration/admin/engines/class-azure_app_service_migration-import-controller.php
@@ -43,6 +43,12 @@ class Azure_app_service_migration_Import_Controller {
 							exit;
 						}
 					}
+
+					// exit after the last function of import process is completed
+					if ($params['priority'] == 10 && $params['completed']) {
+						Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Import successfully completed.', true);
+						exit;
+					}
 				
 					$response = wp_remote_post(                                                                                                        
 						admin_url( 'admin-ajax.php?action=aasm_import' ) ,

--- a/azure_app_service_migration/admin/engines/class-azure_app_service_migration-status.php
+++ b/azure_app_service_migration/admin/engines/class-azure_app_service_migration-status.php
@@ -1,0 +1,47 @@
+<?php
+class Azure_app_service_migration_Status {
+
+    public static function export_status($params) {
+		// Open Import csv file
+		$export_status_file = fopen(AASM_EXPORT_STATUSFILE_PATH, 'r');
+		if (!$export_status_file) {
+			echo json_encode(array('status' => '', 'message' => 'Could not read export status'));
+			wp_die();
+		}
+
+		// get the first row (status) from csv file
+		$row = fgetcsv($export_status_file);
+		if (!$row) {
+			echo json_encode(array('status' => '', 'message' => 'Could not read export status'));
+			wp_die();
+		}
+		fclose($export_status_file);
+
+		// flush status message to browser
+		$export_status = array( 'status' => $row[0], 'message' => $row[1] );
+		echo json_encode($export_status);
+		wp_die();
+    }
+
+	public static function import_status() {
+		// Open Import csv file
+		$import_status_file = fopen(AASM_IMPORT_STATUSFILE_PATH, 'r');
+		if (!$import_status_file) {
+			echo json_encode(array('status' => '', 'message' => 'Could not read import status'));
+			wp_die();
+		}
+
+		// get the first row (status) from csv file
+		$row = fgetcsv($import_status_file);
+		if (!$row) {
+			echo json_encode(array('status' => '', 'message' => 'Could not read import status'));
+			wp_die();
+		}
+		fclose($import_status_file);
+
+		// flush status message to browser
+		$import_status = array( 'status' => $row[0], 'message' => $row[1] );
+		echo json_encode($import_status);
+		wp_die();
+	}
+}

--- a/azure_app_service_migration/admin/engines/export/class-azure_app_service_migration-export-filebackup-handler.php
+++ b/azure_app_service_migration/admin/engines/export/class-azure_app_service_migration-export-filebackup-handler.php
@@ -240,6 +240,7 @@ class Azure_app_service_migration_Export_FileBackupHandler
 
                     try {
                         if (!self::addFilesToZip($zip, $folderPath, $wpContentFolderNameInZip, $excludedFolders, $password, $params)) {
+                            $zip->close();
                             return false;
                         }
                     } catch ( Exception $ex ) {

--- a/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-content.php
+++ b/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-content.php
@@ -63,7 +63,7 @@ class Azure_app_service_migration_Import_Content {
 
         $params['completed'] = $extract_result['completed'];
 
-        if (params['completed']) {
+        if ($params['completed']) {
             $params['priority'] = 20;
             // remove import-content specific params if completed
             unset($params['zip_start_index']);
@@ -141,7 +141,6 @@ class Azure_app_service_migration_Import_Content {
             } catch(Exception $ex) {
                 Azure_app_service_migration_Custom_Logger::handleException($ex);
             }
-            
         }
     }
 

--- a/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-database.php
+++ b/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-database.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Azure_app_service_migration_Import_Database {
-
+/*
     private $import_zip_path = null;
     private $params = null;
     private $new_database_name;
@@ -27,103 +27,196 @@ class Azure_app_service_migration_Import_Database {
         $this->import_zip_path = ($import_zip_path === null)    // Path to the uploaded import zip file
                                 ? AASM_IMPORT_ZIP_LOCATION
                                 : $import_zip_path;
-    }
+    }*/
 
-    public function import_database()
+    public static function import_database($params)
     {
         // Flag to hold if file data has been processed
 		$completed = true;
 
 		// create extractor object for import zip file
-		$archive = new AASM_Zip_Extractor( $this->import_zip_path );        
+		//$archive = new AASM_Zip_Extractor( $this->import_zip_path );
 
         // extract database sql files into temporary directory
-        $archive->extract_database_files(AASM_DATABASE_RELATIVE_PATH_IN_ZIP, $this->db_temp_dir);
+        //$archive->extract_database_files(AASM_DATABASE_RELATIVE_PATH_IN_ZIP, $this->db_temp_dir);
+
+        $database_manager = new AASM_Database_Manager();
+
+        if (!isset($params['old_database_name']))   {
+            $params['old_database_name'] = self::get_old_database_name();
+        }
 
         // create new database
-        $this->database_manager->create_database($this->new_database_name);
+        if (!isset($params['new_database_name']))   {
+            $params['new_database_name'] = self::generate_unique_database_name($params['old_database_name'], $database_manager);
+        }
 
-        //Retrieve the 'siteurl' and 'home' values from the original database options table
-        $originalDataToUpdate = $this->database_manager->get_originaldb_data();
+        if (!isset($params['status'])) {
+            $params['status'] = array();
+        }
+
+        // Create new database
+        if (!isset($params['status']['create_database_status'])) {
+            if ( !$database_manager->create_database($params['new_database_name'])) {
+                throw new Exception('Failed to create new database: ' . $params['new_database_name']);
+            }
+            $params['status']['create_database_status'] = true;
+        }
+
+        // Retrieve the 'siteurl' and 'home' values from the original database options table
+        if (!isset($params['originaldb_data'])) {
+            $params['originaldb_data'] = $database_manager->get_originaldb_data();
+        }
 
         // Import each table sql file into the new database
-        $this->import_db_sql_files();
+        if (!isset($params['status']['import_db_sql_files'])) {
+            if ( ! self::import_db_sql_files($params, $database_manager)) {
+                $params['completed'] = false;
+                return $params;
+            }
+            $params['status']['import_db_sql_files'] = true;
+        }
 
         // update DB_NAME constant in wp-config
-        $this->update_dbname_wp_config($this->new_database_name);
-
-        if(!$this->database_manager->update_originaldb_data($this->new_database_name, $originalDataToUpdate))
-        {
-            Azure_app_service_migration_Custom_Logger::logError(AASM_IMPORT_SERVICE_TYPE, "Couldn't update required original DB values into imported database.");
+        if (!isset($params['status']['update_dbname_wp_config'])) {
+            self::update_dbname_wp_config($params['new_database_name']);
+            $params['status']['update_dbname_wp_config'] = true;
         }
 
-        // imports w3tc options from original DB to new DB
-        if ( isset( $this->params['retain_w3tc_config'] ) && strtoupper($this->params['retain_w3tc_config']) == "TRUE" ) {
-            $this->activate_w3tc_plugin();
+        if (!isset($params['status']['update_originaldb_data'])) {
+            if(!$database_manager->update_originaldb_data($params['new_database_name'], $params['originaldb_data'])) {
+                throw new Exception("Couldn't update required original DB values into imported database.");
+            }
+            $params['status']['update_originaldb_data'] = true;
         }
 
-        // Clean temporary directory to hold sql files
+        if (!isset($params['status']['activate_w3tc_plugin'])) {
+            // imports w3tc options from original DB to new DB
+            if ( isset( $params['retain_w3tc_config'] ) && strtoupper($params['retain_w3tc_config']) == "TRUE" ) {
+                self::activate_w3tc_plugin();
+            }
+            $params['status']['activate_w3tc_plugin'] = true;
+        }
+
+        // Clean DB sql file placeholder directory
         Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Clearing Database files placeholder directory.', true);
-        AASM_Common_Utils::clear_directory_recursive($this->db_temp_dir);
+        if (!isset($params['status']['clear_db_directory'])) {
+            AASM_Common_Utils::clear_directory_recursive(AASM_DATABASE_TEMP_DIR);
+            $params['status']['clear_db_directory'] = true;
+        }
 
         Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Database import complete.', true);
+        $params['completed'] = true;
+
+        if ($params['completed']) {
+            unset($params['old_database_name']);
+            unset($params['new_database_name']);
+            unset($params['status']);
+            unset($params['originaldb_data']);
+            $params['priority'] = 40;
+        }
+
+        return $params;
+    }
+
+    public static function get_old_database_name() {
+        global $wpdb;
+        $hostname = $wpdb->dbhost;
+        $username = $wpdb->dbuser;
+        $password = $wpdb->dbpassword;
+
+        return $wpdb->$dbname;
     }
 
     // Imports all sql files in wp-database/ directory inside the import zip file
-    private function import_db_sql_files() {
-        if (!file_exists($this->db_temp_dir)) {
-            mkdir($this->db_temp_dir, 0777, true);
+    private static function import_db_sql_files($params, $database_manager) {
+        // Initialize completed flag
+        $completed = true;
+
+        // Start time
+		$start = microtime( true );
+
+        if (!file_exists(AASM_DATABASE_SQL_DIR)) {
+            mkdir(AASM_DATABASE_SQL_DIR, 0777, true);
         }
 
         Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Importing Database tables and records.', true);
-        $files = scandir($this->db_temp_dir);
+        $files = scandir(AASM_DATABASE_SQL_DIR);
         $table_records_files = [];
 
-        // import table structure and keep track of table records to be imported later
+        // Import table structure and keep track of table records to be imported later
         foreach ($files as $file) {
-            // reset time counter to prevent timeout
+            // break when timeout (20s) is reached
+            if ( ( microtime( true ) - $start ) > 20 ) {
+                $last_zip_index = $i;
+                $completed = false;
+                break;
+            }
+
+            // Reset time counter to prevent timeout
             set_time_limit(0);
+
             // Exclude current directory (.) and parent directory (..)
             if ($file != '.' && $file != '..') {
-                $filePath = $this->db_temp_dir . $file;
+                $filePath = AASM_DATABASE_SQL_DIR . $file;
 
                 // Check if the path is a file
                 if (is_file($filePath) && str_ends_with($filePath, 'structure.sql')) {
-                    if (!$this->database_manager->import_sql_file($this->new_database_name, $filePath)) {
-                        Azure_app_service_migration_Custom_Logger::logError(AASM_IMPORT_SERVICE_TYPE, "Couldn't import " . $filePath . " into database.");
+                    if (!$database_manager->import_sql_file($params['new_database_name'], $filePath)) {
+                        throw new Exception("Couldn't import " . $filePath . " into database.");
                     }
+
+                    // delete sql schema structure file once imported
+                    unlink($filePath);
                 }
-                else if (is_file($filePath) && str_ends_with($filePath, '.sql'))
-                {
+                else if (is_file($filePath) && str_ends_with($filePath, '.sql')) {
                     $table_records_files[] = $filePath;
                 }
             }
+        }
+
+        if (! $completed) {
+            return false;
         }
 
         Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Finished importing Database tables. Importing database records...', true);
         // Import table records
         foreach ($table_records_files as $table_records) {
             set_time_limit(0);
-            if (!$this->database_manager->import_sql_file($this->new_database_name, $table_records)) {
+
+            // break when timeout (20s) is reached
+            if ( ( microtime( true ) - $start ) > 20 ) {
+                $last_zip_index = $i;
+                $completed = false;
+                break;
+            }
+
+            if (!$database_manager->import_sql_file($params['new_database_name'], $table_records)) {
                 Azure_app_service_migration_Custom_Logger::logError(AASM_IMPORT_SERVICE_TYPE, "Couldn't import " . $table_records . " into database.");
             }
+
+            // delete table records file once imported
+            unlink($table_records);
         }
+
+        return $completed;
     }
 
     // Activates W3 Total Cache plugin
-    private function activate_w3tc_plugin() {
+    private static function activate_w3tc_plugin() {
         Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Activating W3 Total Cache Plugin.', true);
 
         $plugin_to_activate = AASM_W3TC_PLUGIN_FILE_PATH;
 
         // Check if the plugin is already active.
+        //To Do: deactivate and reactivate the plugin if already active
         if (is_plugin_active($plugin_to_activate)) {
             return;
         }
-    
+
         // Activate the plugin.
         $activate = activate_plugin($plugin_to_activate);
-    
+
         // Check if the activation was successful.
         if (is_wp_error($activate)) {
             Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Could not activate W3 Total Cache plugin.', true);
@@ -160,14 +253,14 @@ class Azure_app_service_migration_Import_Database {
     }
 
     // Generates a unique database name. Retries 5 times
-    private function generate_unique_database_name($current_dbname, $database_manager) {
+    private static function generate_unique_database_name($current_dbname, $database_manager) {
         Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Generating new database name.', true);
         $dbname_suffix = substr($current_dbname, 0, min(strlen($current_dbname), 10));
 
         for ($trycount = 0; $trycount < 5; $trycount++) {
             $new_dbname = $dbname_suffix . '_aasm_db_' . AASM_Common_Utils::generate_random_string_short();
             
-            if (!($this->database_manager->database_exists($new_dbname)))
+            if (!($database_manager->database_exists($new_dbname)))
                 return $new_dbname;
         }
 

--- a/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-filebackup-handler.php
+++ b/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-filebackup-handler.php
@@ -110,7 +110,7 @@ class Azure_app_service_migration_Import_FileBackupHandler
 					$completed = false;
 					break;
 				}
-                
+
                 // Read the content of the current chunk file
                 $chunkContent = file_get_contents($chunkFile);
 
@@ -145,6 +145,7 @@ class Azure_app_service_migration_Import_FileBackupHandler
 
                 // sets enumerate_content as the next function to be executed
                 $params['priority'] = 10;
+                $params['zip_entry_starting_point'] = null;
             }
 
             return $params;

--- a/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-filebackup-handler.php
+++ b/azure_app_service_migration/admin/engines/import/class-azure_app_service_migration-import-filebackup-handler.php
@@ -106,6 +106,7 @@ class Azure_app_service_migration_Import_FileBackupHandler
             $chunkFile = $uploadDir . $chunkPrefix . $chunkIndex;
 
             while (file_exists($chunkFile)) {
+                Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Extracting chunk file: ' . $chunkFile, true);
                 if ( ( microtime( true ) - $start ) > $timeout ) {
 					$completed = false;
 					break;
@@ -145,7 +146,7 @@ class Azure_app_service_migration_Import_FileBackupHandler
 
                 // sets enumerate_content as the next function to be executed
                 $params['priority'] = 10;
-                $params['zip_entry_starting_point'] = null;
+                $params['zip_start_index'] = 0;
             }
 
             return $params;

--- a/azure_app_service_migration/admin/engines/js/azure_app_service_migration-controller.js
+++ b/azure_app_service_migration/admin/engines/js/azure_app_service_migration-controller.js
@@ -27,12 +27,15 @@ jQuery(function ($) {
 			dataType: "json",
 			success: function (data) {
 				console.log(data);
+				//start getting export status 
+				getExportStatus(0);
+
 				if (data.status == 1) {
 					showAlert(data.message);
 					$("#exportdownloadfile").show();
 					$('#downloadLink').show().css('display', 'inline-block');
 					blinkElement("#exportdownloadfile");
-					$('#exportdownloadfile').load(window.location.href + ' #exportdownloadfile');
+					$('#exportdownloadfile').load(window.location.href + ' #exportdownloadfile');					
 				} else {
 					showAlert(data.message);
 				}
@@ -47,7 +50,6 @@ jQuery(function ($) {
 			}
 		});
 	});
-	
   
 	function showAlert(message) {
 		var alertBox = document.querySelector('.alert-container');
@@ -83,7 +85,38 @@ jQuery(function ($) {
 		clearInterval(blinkInterval);
 		clearTimeout(blinkTimeout);
 		element.stop().show();
-	  }   
+	  }
+
+	  function getExportStatus(retryCount) {
+		// Set max retry count for getting status from server
+		maxRetryCount = 10;
+	
+		$.ajax({
+		  url: ajaxurl,
+		  type: 'POST',
+		  dataType: 'json',
+		  data: {
+			action: 'aasm_export_status', // Adjust the server-side action name
+		  },
+		  success: function(response) {
+			if (response.status === 'done' ) {
+				("#generatefile").prop("disabled", false).text("Generate Export File"); 
+				showAlert("Export Completed!");
+			}
+			else if (!(response.status === 'exception') && !(response.status === 'error')) {
+				setTimeout(function() {
+					getExportStatus(0);
+				},2000);
+			}
+		  },
+		  error: function(xhr, status, error) {
+			// Retry the updateStatus call if the maximum number of retries is not reached
+			if (retryCount < maxRetryCount) {
+				getExportStatus(retryCount+1);
+			}
+		  }
+		});
+	}
    
 	// Add event listeners for drag and drop functionality
 	$("#dropzone")

--- a/azure_app_service_migration/admin/engines/js/azure_app_service_migration-controller.js
+++ b/azure_app_service_migration/admin/engines/js/azure_app_service_migration-controller.js
@@ -17,8 +17,9 @@ jQuery(function ($) {
 		$(this).prop("disabled", true).text("Generating Export...");
 	
 		var postdata = $("#frm-chkbox-data").serialize();
-		postdata += "&action=admin_ajax_request&param=wp_filebackup";
-	
+		postdata += "&action=aasm_export&param=wp_filebackup";
+		postdata += "&is_first_request=true";
+
 		$.ajax({
 			url: ajaxurl,
 			type: "POST",
@@ -39,7 +40,7 @@ jQuery(function ($) {
 			error: function (jqXHR, textStatus, errorThrown) {
 				console.log("AJAX request failed: " + textStatus + ", " + errorThrown);
 				showAlert("An error occurred while processing the request.");
-				$('#downloadLink').show().css('display', 'inline-block');;
+				$('#downloadLink').show().css('display', 'inline-block');
 			},
 			complete: function () {
 				$("#generatefile").prop("disabled", false).text("Generate Export File");

--- a/azure_app_service_migration/admin/partials/tmpl_import.php
+++ b/azure_app_service_migration/admin/partials/tmpl_import.php
@@ -250,9 +250,12 @@ function combineChunksWithRetry(
     url: ajaxurl,
     type: 'POST',
     data: {
-      action: 'handle_combine_chunks',
+      action: 'aasm_import',
       param: 'wp_ImportFile',
       retain_w3tc_config: w3tc_checkbox.checked,
+      chunk_index: 0,
+      priority: 5,
+      is_first_request: true,
     },
     success: function (response) {
       console.log(response);
@@ -260,11 +263,11 @@ function combineChunksWithRetry(
       var fileInput = document.getElementById('importFile');
       fileInput.value = '';
       document.getElementById('progressBarContainer').style.display = 'none'; // Hide the progress bar
-      deleteChunks(); // Delete the chunk files
+      //deleteChunks(); // Delete the chunk files
     },
     error: function (xhr, status, error) {
       console.log(error);
-      fileInfo.textContent = 'Import exited. Check Import Log File for completion...';
+      fileInfo.textContent = `Import Failed with error: ${error}`;
       /*
       if (retries < maxRetries) {
         retries++;

--- a/azure_app_service_migration/admin/partials/tmpl_import.php
+++ b/azure_app_service_migration/admin/partials/tmpl_import.php
@@ -73,91 +73,38 @@ $reducedSize = (int) $trimmedSize * 0.5; // Convert the trimmed size to an integ
     }
   }
 
-  // To Do: Commenting out this function for now since it may prevent Import/Export in some cases
-    /*function verifyMigrationStatus(retryCount) {
-      // Set max retry count for getting status from server
-      maxRetryCount = 5;
-
-      $.ajax({
-        url: ajaxurl,
-        type: 'POST',
-        dataType: 'json',
-        data: {
-          action: 'get_migration_status', // Adjust the server-side action name
-        },
-        success: function(response) {
-          // Handle the success response after combining the chunks
-          console.log(response);
-          
-          // To Do (Sudhakar): Display popup message here when import/export already in progress
-          // Currently updating the statusText Value
-          if (response.type == 'status')
-          {
-            // Update status text value
-            statusText.textContent = 'Import/Export process is already running on the server! Please wait a while and try again.';
-          }
-          else
-          {
-            // Update status text value
-            statusText.textContent = 'Starting Migration.';
-
-            // Start Import process (with uploading zip file) if there is no Import/Export in progress
-            document.getElementById('progressBarContainer').style.display = 'block'; // Display the progress bar
-            uploadChunkWithRetry();
-          }
-        },
-        error: function(xhr, status, error) {
-          // Retry the updateStatus call if the maximum number of retries is not reached
-          if (retryCount < maxRetryCount) {
-            updateStatusText(retryCount+1);
-          } else {
-            // Max retries reached, display error message
-            statusText.textContent = 'Failed to connect to server. Import can still be in progress';
-          }
-        }
-      });
-    }
-    */
-
-  // Makes a GET request to the server to get IMPORT status
-  function updateStatusText(retryCount) {
+  function getMigrationStatus(retryCount) {
     // Set max retry count for getting status from server
-    maxRetryCount = 15;
+    maxRetryCount = 10;
 
     $.ajax({
       url: ajaxurl,
       type: 'POST',
       dataType: 'json',
       data: {
-        action: 'get_migration_status', // Adjust the server-side action name
+        action: 'aasm_import_status', // Adjust the server-side action name
       },
       success: function(response) {
         // Handle the success response after combining the chunks
         console.log(response);
         
-        // To Do (Sudhakar): Display response.message in status box.
-        // Currently updating a text field (statusText) in the page. 
-        
-        // Update status text value
-        statusText.textContent = response.message;
-        
-        // Call updateStatusText recursively only if migration is still in progress
-        if (response.type == 'status')
+        // Currently updating the fileInfo Value
+        if (response.status === 'info' || response.status === 'error' || response.status === 'exception' || response.status === 'done')
         {
-          updateStatusText(0);
-          return;
+          // Update status text value
+          fileInfo.textContent = response.message;
+        }
+
+        if (!(response.status === 'exception') && !(response.status === 'error') && !(response.status === 'done')) {
+          setTimeout(function() {
+            getMigrationStatus(0);
+          }, 2000);
         }
       },
       error: function(xhr, status, error) {
-        // Handle the error response
-        console.log(error);
-
         // Retry the updateStatus call if the maximum number of retries is not reached
         if (retryCount < maxRetryCount) {
-          updateStatusText(retryCount+1);
-        } else {
-          // Max retries reached, display error message
-          statusText.textContent = 'Failed to connect to server. Import can still be in progress';
+          getMigrationStatus(retryCount+1);
         }
       }
     });
@@ -259,39 +206,20 @@ function combineChunksWithRetry(
     },
     success: function (response) {
       console.log(response);
-      fileInfo.textContent = 'File imported successfully.';
+      fileInfo.textContent = 'Importing...';
       var fileInput = document.getElementById('importFile');
       fileInput.value = '';
       document.getElementById('progressBarContainer').style.display = 'none'; // Hide the progress bar
+      getMigrationStatus(0);
       //deleteChunks(); // Delete the chunk files
     },
     error: function (xhr, status, error) {
       console.log(error);
       fileInfo.textContent = `Import Failed with error: ${error}`;
-      /*
-      if (retries < maxRetries) {
-        retries++;
-        setTimeout(function () {
-          combineChunksWithRetry(
-            ajaxurl,
-            w3tc_checkbox,
-            formData,
-            fileInfo,
-            retries,
-            maxRetries,
-            retryDelay
-          );
-        }, retryDelay);
-      } else {
-        fileInfo.textContent =
-          'Failed to import file after multiple retries.';
-        document.getElementById('progressBarContainer').style.display = 'none'; // Hide the progress bar
-        deleteChunks(); // Delete the chunk files
-      }*/
     },    
     complete: function() {
       document.getElementById('btnImportfile').disabled = false;      
-      $('#downloadLink').show().css('display', 'inline-block');;
+      $('#downloadLink').show().css('display', 'inline-block');
     },
   });
 }

--- a/azure_app_service_migration/constants.php
+++ b/azure_app_service_migration/constants.php
@@ -29,6 +29,11 @@ define( 'AASM_EXPORT_ZIP_LOCATION', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PA
 // ================
 // = Import Zip File Storage Path =
 // ================
+define( 'AASM_IMPORT_ZIP_FILE', AASM_IMPORT_ZIP_LOCATION . 'importfile.zip');
+
+// ================
+// = Import Zip File Storage Path =
+// ================
 define( 'AASM_IMPORT_ZIP_PATH', AZURE_APP_SERVICE_MIGRATION_PLUGIN_PATH . 
                                 'storage' . DIRECTORY_SEPARATOR . 
                                 'import' . DIRECTORY_SEPARATOR .

--- a/azure_app_service_migration/constants.php
+++ b/azure_app_service_migration/constants.php
@@ -157,3 +157,15 @@ define( 'AASM_EXPORT_LOGFILE_PATH', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PA
 define( 'AASM_PLUGIN_RELATIVE_PATH', 'wp-content' . DIRECTORY_SEPARATOR . 
                                     'plugins' . DIRECTORY_SEPARATOR . 
                                     AASM_PLUGIN_NAME . DIRECTORY_SEPARATOR);
+
+// ==============
+// = Export Status file path =
+// ==============
+define( 'AASM_EXPORT_STATUSFILE_PATH', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PATH, 0, -1) . DIRECTORY_SEPARATOR . 'Logs' . 
+DIRECTORY_SEPARATOR . 'export_status.csv');
+
+// ==============
+// = Import Status file path =
+// ==============
+define( 'AASM_IMPORT_STATUSFILE_PATH', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PATH, 0, -1) . DIRECTORY_SEPARATOR . 'Logs' . 
+DIRECTORY_SEPARATOR . 'import_status.csv');

--- a/azure_app_service_migration/constants.php
+++ b/azure_app_service_migration/constants.php
@@ -26,6 +26,9 @@ define( 'AASM_IMPORT_ZIP_LOCATION', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PA
 define( 'AASM_EXPORT_ZIP_LOCATION', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PATH, 0, -1) . DIRECTORY_SEPARATOR . 
                                     'ExportedFile' . DIRECTORY_SEPARATOR);
 
+define( 'AASM_EXPORT_ENUMERATE_FILE', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PATH, 0, -1) . DIRECTORY_SEPARATOR . 
+'ExportedFile' . DIRECTORY_SEPARATOR . 'content_enumerate.csv');
+
 // ================
 // = Import Zip File Storage Path =
 // ================
@@ -58,6 +61,12 @@ define( 'AASM_PLUGIN_RELATIVE_PATH_IN_ZIP', 'wp-content' . DIRECTORY_SEPARATOR .
 // ================
 define( 'AASM_DATABASE_TEMP_DIR', AZURE_APP_SERVICE_MIGRATION_PLUGIN_PATH . 'storage' . 
                                 DIRECTORY_SEPARATOR . 'dbtempdir' . DIRECTORY_SEPARATOR );
+
+// ================
+// = Directory to extract sql files to =
+// ================
+define( 'AASM_DATABASE_SQL_DIR', AASM_DATABASE_TEMP_DIR . 'wp-database' . 
+                                DIRECTORY_SEPARATOR );
 
 // ================
 // = Uploads folder path =
@@ -141,3 +150,10 @@ define( 'AASM_IMPORT_LOGFILE_PATH', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PA
 // ==============
 define( 'AASM_EXPORT_LOGFILE_PATH', substr(AZURE_APP_SERVICE_MIGRATION_PLUGIN_PATH, 0, -1) . DIRECTORY_SEPARATOR . 'Logs' . 
                                     DIRECTORY_SEPARATOR . 'export_log.txt');
+
+// ==============
+// = AASM plugin relative path to abspath =
+// ==============
+define( 'AASM_PLUGIN_RELATIVE_PATH', 'wp-content' . DIRECTORY_SEPARATOR . 
+                                    'plugins' . DIRECTORY_SEPARATOR . 
+                                    AASM_PLUGIN_NAME . DIRECTORY_SEPARATOR);

--- a/azure_app_service_migration/includes/class-azure_app_service_migration.php
+++ b/azure_app_service_migration/includes/class-azure_app_service_migration.php
@@ -140,9 +140,14 @@ class Azure_app_service_migration
         require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/export/class-azure_app_service_migration-export-filebackup-handler.php';
 
         /**
-        +        * The class responsible for calling all actions for Import.
+                * The class responsible for calling all actions for Import.
+                */
+        require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/class-azure_app_service_migration-import-controller.php';
+
+        /**
+        +        * The class responsible for calling all actions for Export.
         +        */
-        +require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/class-azure_app_service_migration-import-controller.php';
+        +require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/class-azure_app_service_migration-export.php';
 
         /**
         +        * The class responsible for defining actions for wp-content import.
@@ -236,19 +241,21 @@ class Azure_app_service_migration
 
         $this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');
         $this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts');
+        
         // action hook for admin menu
         $this->loader->add_action('admin_menu', $plugin_admin, 'azure_app_service_migration_menu');
+        
         // Register the AJAX handler
         $ajaxHandler = new Azure_app_service_migration_Export_AjaxHandler();
         $this->loader->add_action('wp_ajax_admin_ajax_request', $ajaxHandler, 'handle_ajax_requests_admin');
 
         $importaxHandler = new Azure_app_service_migration_Import_FileBackupHandler();
         
-        $this->loader->add_action('wp_ajax_handle_upload_chunk', 'Azure_app_service_migration_Import_FileBackupHandler::handle_upload_chunk');
+        add_action('wp_ajax_handle_upload_chunk', 'Azure_app_service_migration_Import_FileBackupHandler::handle_upload_chunk');
 
-        $this->loader->add_action('wp_ajax_handle_combine_chunks', 'Azure_app_service_migration_Import_FileBackupHandler::handle_combine_chunks');
+        add_action('wp_ajax_handle_combine_chunks', 'Azure_app_service_migration_Import_FileBackupHandler::handle_combine_chunks');
 
-        $this->loader->add_action('wp_ajax_delete_chunks', 'Azure_app_service_migration_Import_FileBackupHandler::delete_chunks');
+        add_action('wp_ajax_delete_chunks', 'Azure_app_service_migration_Import_FileBackupHandler::delete_chunks');
 
         // Register status update AJAX handler
         $statusUpdateHandler = new Azure_app_service_migration_Import_AjaxHandler();
@@ -258,10 +265,17 @@ class Azure_app_service_migration
         add_action('wp_ajax_aasm_import','Azure_app_service_migration_Import_Controller::import');
         add_action('wp_ajax_nopriv_aasm_import', 'Azure_app_service_migration_Import_Controller::import');
 
+        // register export ajax handler
+        add_action('wp_ajax_aasm_export','Azure_app_service_migration_Export::export');
+        add_action('wp_ajax_nopriv_aasm_export', 'Azure_app_service_migration_Export::export');
+
         // register function hooks for import
         add_filter( 'aasm_import', 'Azure_app_service_migration_Import_FileBackupHandler::handle_combine_chunks', 5 );
 		add_filter( 'aasm_import', 'Azure_app_service_migration_Import_Content::import_content', 10 );
+        add_filter( 'aasm_import', 'Azure_app_service_migration_Import_Database::import_database', 20 );
 
+        // register function hooks for export
+        add_filter( 'aasm_export', 'Azure_app_service_migration_Export_FileBackupHandler::handle_wp_filebackup', 5 );
     }
 
     /**

--- a/azure_app_service_migration/includes/class-azure_app_service_migration.php
+++ b/azure_app_service_migration/includes/class-azure_app_service_migration.php
@@ -150,6 +150,11 @@ class Azure_app_service_migration
         +require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/class-azure_app_service_migration-export.php';
 
         /**
+        +        * The class responsible for calling all actions for Export.
+        +        */
+        +require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/class-azure_app_service_migration-export.php';
+
+        /**
         +        * The class responsible for defining actions for wp-content import.
         +        */
         +require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/import/class-azure_app_service_migration-import-content.php';
@@ -175,6 +180,11 @@ class Azure_app_service_migration
         /**
          * The class responsible for handling the import filebackup
          */require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/import/class-azure_app_service_migration-import-filebackup-handler.php';
+
+        /**
+         * The class responsible for handling status
+         */
+        require_once plugin_dir_path(dirname(__FILE__)) . 'admin/engines/class-azure_app_service_migration-status.php';
 
         /**
         +        * The class responsible for defining database helper functions.
@@ -250,7 +260,7 @@ class Azure_app_service_migration
         $this->loader->add_action('wp_ajax_admin_ajax_request', $ajaxHandler, 'handle_ajax_requests_admin');
 
         $importaxHandler = new Azure_app_service_migration_Import_FileBackupHandler();
-        
+
         add_action('wp_ajax_handle_upload_chunk', 'Azure_app_service_migration_Import_FileBackupHandler::handle_upload_chunk');
 
         add_action('wp_ajax_handle_combine_chunks', 'Azure_app_service_migration_Import_FileBackupHandler::handle_combine_chunks');
@@ -276,6 +286,10 @@ class Azure_app_service_migration
 
         // register function hooks for export
         add_filter( 'aasm_export', 'Azure_app_service_migration_Export_FileBackupHandler::handle_wp_filebackup', 5 );
+
+        // register migration status actions
+        add_action( 'wp_ajax_aasm_import_status', 'Azure_app_service_migration_Status::import_status');
+        add_action( 'wp_ajax_aasm_export_status', 'Azure_app_service_migration_Status::export_status');
     }
 
     /**

--- a/azure_app_service_migration/includes/class-azure_app_service_migration.php
+++ b/azure_app_service_migration/includes/class-azure_app_service_migration.php
@@ -260,8 +260,7 @@ class Azure_app_service_migration
 
         // register function hooks for import
         add_filter( 'aasm_import', 'Azure_app_service_migration_Import_FileBackupHandler::handle_combine_chunks', 5 );
-		add_filter( 'aasm_import', 'Azure_app_service_migration_Import_Content::enumerate_content', 10 );
-		add_filter( 'aasm_import', 'Azure_app_service_migration_Import_Content::extract_content', 50 );
+		add_filter( 'aasm_import', 'Azure_app_service_migration_Import_Content::import_content', 10 );
 
     }
 

--- a/azure_app_service_migration/includes/class-azure_app_service_migration.php
+++ b/azure_app_service_migration/includes/class-azure_app_service_migration.php
@@ -232,7 +232,6 @@ class Azure_app_service_migration
      */
     private function define_admin_hooks()
     {
-
         $plugin_admin = new Azure_app_service_migration_Export_Controller($this->get_plugin_name(), $this->get_version());
 
         $this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');
@@ -245,15 +244,24 @@ class Azure_app_service_migration
 
         $importaxHandler = new Azure_app_service_migration_Import_FileBackupHandler();
         
-        $this->loader->add_action('wp_ajax_handle_upload_chunk', $importaxHandler , 'handle_upload_chunk');
+        $this->loader->add_action('wp_ajax_handle_upload_chunk', 'Azure_app_service_migration_Import_FileBackupHandler::handle_upload_chunk');
 
-        $this->loader->add_action('wp_ajax_handle_combine_chunks', $importaxHandler , 'handle_combine_chunks');
+        $this->loader->add_action('wp_ajax_handle_combine_chunks', 'Azure_app_service_migration_Import_FileBackupHandler::handle_combine_chunks');
 
-        $this->loader->add_action('wp_ajax_delete_chunks', $importaxHandler, 'delete_chunks');
+        $this->loader->add_action('wp_ajax_delete_chunks', 'Azure_app_service_migration_Import_FileBackupHandler::delete_chunks');
 
         // Register status update AJAX handler
         $statusUpdateHandler = new Azure_app_service_migration_Import_AjaxHandler();
         $this->loader->add_action('wp_ajax_get_migration_status', $statusUpdateHandler , 'get_migration_status');
+
+        // register import ajax handler
+        add_action('wp_ajax_aasm_import','Azure_app_service_migration_Import_Controller::import');
+        add_action('wp_ajax_nopriv_aasm_import', 'Azure_app_service_migration_Import_Controller::import');
+
+        // register function hooks for import
+        add_filter( 'aasm_import', 'Azure_app_service_migration_Import_FileBackupHandler::handle_combine_chunks', 5 );
+		add_filter( 'aasm_import', 'Azure_app_service_migration_Import_Content::enumerate_content', 10 );
+		add_filter( 'aasm_import', 'Azure_app_service_migration_Import_Content::extract_content', 50 );
 
     }
 

--- a/azure_app_service_migration/utils/class-common_utils.php
+++ b/azure_app_service_migration/utils/class-common_utils.php
@@ -51,7 +51,7 @@ class AASM_Common_Utils {
         return $filters;
     }
 
-    public function http_export_headers( $headers = array() ) {
+    public static function http_export_headers( $headers = array() ) {
 	
         $user = "";
         $password = "";

--- a/azure_app_service_migration/utils/class-common_utils.php
+++ b/azure_app_service_migration/utils/class-common_utils.php
@@ -33,4 +33,45 @@ class AASM_Common_Utils {
     public static function replace_forward_slash_with_directory_separator ( $dir ) {
         return str_replace("/", DIRECTORY_SEPARATOR, $dir);
     }
+
+    // gets all the callback functions registered to a filter
+    public static function get_filter_callbacks($filter_tag) {
+        global $wp_filter;
+
+        $filters = array();
+
+        if ( isset( $wp_filter[ $filter_tag ] ) ) {
+            $filters = $wp_filter[ $filter_tag ];
+            if ( isset( $filters->callbacks ) ) {
+                $filters = $filters->callbacks;
+            }
+
+            ksort( $filters );
+        }
+        return $filters;
+    }
+
+    public function http_export_headers( $headers = array() ) {
+	
+        $user = "";
+        $password = "";
+
+        // Set user
+        if ( isset( $_SERVER['PHP_AUTH_USER'] ) ) {
+            $user = $SERVER['PHP_AUTH_USER'];
+        } elseif ( isset( $_SERVER['REMOTE_USER'] ) ) {
+            $user = $_SERVER['REMOTE_USER'];
+        }
+    
+        // Set password
+        if ( isset( $_SERVER['PHP_AUTH_PW'] ) ) {
+            $password = $_SERVER['PHP_AUTH_PW'];
+        }
+        
+        // Set Authorization header
+        if ( ( $hash = base64_encode( sprintf( '%s:%s', $user, $password ) ) ) ) {
+            $headers['Authorization'] = sprintf( 'Basic %s', $hash );
+        }
+        return $headers;
+    }	
 }

--- a/azure_app_service_migration/utils/class-common_utils.php
+++ b/azure_app_service_migration/utils/class-common_utils.php
@@ -14,20 +14,29 @@ class AASM_Common_Utils {
     }
 
     public static function clear_directory_recursive($directoryPath) {
+        // Remove trailing '/'
+        if (str_ends_with($directoryPath, DIRECTORY_SEPARATOR)) {                                                                      
+            $directoryPath = substr($directoryPath, 0, -1);                                                                        
+        }
+        
         // Retrieve list of files and directories in the directory
-        $files = glob($directoryPath . '/*');
+        $files = scandir($directoryPath);
       
         // Iterate over each file or directory
         foreach ($files as $file) {
-            if (is_file($file)) {
-                unlink($file);
-            } elseif (is_dir($file)) {
-                // Recursively clear subdirectory
-                clear_directory($file);
-                // Remove empty subdirectory
-                rmdir($file);
+            if ($file !== '.' && $file !== '..') {
+                $path = $directoryPath . DIRECTORY_SEPARATOR . $file;
+                if (is_file($path)) {
+                    unlink($path);
+                } elseif (is_dir($path)) {
+                    // Recursively clear subdirectory
+                    clear_directory_recursive( $path);
+                    // Remove empty subdirectory
+                    rmdir($path);
+                }
             }
         }
+        rmdir($directoryPath);
     }
 
     public static function replace_forward_slash_with_directory_separator ( $dir ) {

--- a/azure_app_service_migration/utils/class-common_utils.php
+++ b/azure_app_service_migration/utils/class-common_utils.php
@@ -30,7 +30,7 @@ class AASM_Common_Utils {
                     unlink($path);
                 } elseif (is_dir($path)) {
                     // Recursively clear subdirectory
-                    clear_directory_recursive( $path);
+                    self::clear_directory_recursive( $path);
                     // Remove empty subdirectory
                     rmdir($path);
                 }
@@ -82,5 +82,23 @@ class AASM_Common_Utils {
             $headers['Authorization'] = sprintf( 'Basic %s', $hash );
         }
         return $headers;
-    }	
+    }
+
+    private static function initialize_status_file($serviceType) {
+        $statusFilePath = $serviceType === AASM_IMPORT_SERVICE_TYPE
+                        ? AASM_IMPORT_STATUSFILE_PATH
+                        : AASM_EXPORT_STATUSFILE_PATH;
+
+		if (file_exists($statusFilePath))
+			unlink($statusFilePath);
+		
+		// open statusfile
+		$statusFile = fopen($statusFilePath, 'w');
+		
+		// write status
+		fputcsv($statusFile, ['info', 'Importing...']);
+		
+		// close file
+		fclose($statusFile);
+	}
 }

--- a/azure_app_service_migration/utils/class-custom-logger.php
+++ b/azure_app_service_migration/utils/class-custom-logger.php
@@ -20,7 +20,7 @@ class Azure_app_service_migration_Custom_Logger
 
         // Create the log file if it doesn't exist
         if (!file_exists($log_file)) {
-            file_put_contents($log_file, 'Azure App Service Migration IMPORT Logs' . PHP_EOL . PHP_EOL);
+            file_put_contents($log_file, 'Azure App Service Migration' . $service_type . 'Logs' . PHP_EOL . PHP_EOL);
         }
     }
 
@@ -65,9 +65,8 @@ class Azure_app_service_migration_Custom_Logger
         if ($echo_status) {
             $migration_status = array( 'status' => 'error', 'message' => $error_message );
             echo json_encode($migration_status);
-
-            wp_die();
         }
+        wp_die();
     }
 
     // Custom error handler

--- a/azure_app_service_migration/utils/class-database_manager.php
+++ b/azure_app_service_migration/utils/class-database_manager.php
@@ -59,8 +59,9 @@ class AASM_Database_Manager {
         $query = "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$databaseName';";
         $result = $wpdb->get_row($query);
         return !empty($result);
-    }    
-     // Update the 'siteurl' and 'home' values in the options table of the original WordPress database
+    }
+    
+    // Update the 'siteurl' and 'home' values in the options table of the original WordPress database
     public function update_originaldb_data($newDatabaseName,$originalDataToUpdate )
     {
         $databaseConstants = $this->get_database_constants();

--- a/azure_app_service_migration/utils/class-zip_extractor.php
+++ b/azure_app_service_migration/utils/class-zip_extractor.php
@@ -68,13 +68,18 @@ class AASM_Zip_Extractor {
                 }
             }
 
+            // database sql files should not be excluded 
+            if (str_starts_with( $filename, AASM_DATABASE_RELATIVE_PATH_IN_ZIP)) {
+                $should_exclude_file = false;
+            }
+
             if ($should_exclude_file === false) {
                 $path_file = $this->replace_forward_slash_with_directory_separator($destination_dir);
                 if (str_starts_with($filename, AASM_DATABASE_RELATIVE_PATH_IN_ZIP)) {
                     $path_file = $this->replace_forward_slash_with_directory_separator(AASM_DATABASE_TEMP_DIR);
                 }
                 
-                $new_dir = dirname($path_file);
+                $new_dir = dirname($path_file . $filename);
                 if (!str_ends_with($new_dir, DIRECTORY_SEPARATOR)) {
                     $new_dir .= DIRECTORY_SEPARATOR;
                 }

--- a/azure_app_service_migration/utils/class-zip_extractor.php
+++ b/azure_app_service_migration/utils/class-zip_extractor.php
@@ -1,23 +1,25 @@
 <?php
-
+// TO DO: This file will be redundant and needs to be deleted once batch processing is implemented for import
 class AASM_Zip_Extractor {
     private $zip_path = null;
     private $file_handle = null;
+    private $eof = null;
 
     public function __construct( $zip_file_name ) {
         $this->zip_path = $zip_file_name;
         
-        // Open input zip file for reading
+        /*// Open input zip file for reading
         if ( ( $this->file_handle = @fopen( $zip_file_name, 'rb' ) ) === false ) {
             throw new AASM_File_Not_Found_Exception( "File Not Found: Couldn't find file at " . $zip_file_name );
-        }
+        }*/
     }
     
-    public function extract( $destination_dir, $files_to_exclude = [] ) {
+    public function extract( $destination_dir, $files_to_exclude = [], $zip_entry_starting_point ) {
+        // reset time counter to prevent timeout
+        set_time_limit(0);
 
         $destination_dir = $this->replace_forward_slash_with_directory_separator($destination_dir);
-        if ($destination_dir === null)
-        {
+        if ($destination_dir === null) {
             throw new AASM_Archive_Destination_Dir_Exception ('Zip extract error: Target destination not provided.');
         }
 
@@ -27,66 +29,98 @@ class AASM_Zip_Extractor {
         } catch ( Exception $ex ) {
             Azure_app_service_migration_Custom_Logger::handleException($ex);
         }
-        
+
+        // Defines if the current file is to be skipped
+        // A file is skipped if it has been extracted previously
+        $skip_file = true;
+
+        // total number of files in the zip file
+        $totalEntries = $zip->numFiles;
+
+        // track last zip_entry extracted in this session
+        $last_zip_entry = null;
+
+        // maintain counter of zip_entry objects
         $count=0;
-        while ($zip_entry = zip_read($zip))
-        {
-            $filename = $this->replace_forward_slash_with_directory_separator(zip_entry_name($zip_entry));
+        while ($zip_entry = zip_read($zip)) {
+            // break when timeout (20s) is reached
+            if ( ( microtime( true ) - $start ) > 20 ) {
+                
+                // Throw exception if starting point could not be reached in 20s 
+                if ( $skip_file ) {
+                    throw new Exception('Failed to extract wp-content... Infinite loop encountered.');
+                }
+
+                $last_zip_entry = zip_entry_name($zip_entry);
+                $completed = false;
+                break;
+            }
+            $count++;
+
+            // if zip_entry_starting_point is null, assign it to the first instance of zip_entry
+            // This ensures we start extracting from beginning of zip file
+            if (is_null($zip_entry_starting_point) && $count === 1)
+                $zip_entry_starting_point = zip_entry_name($zip_entry);
             
+            // Start extracting when zip_entry_starting_point is encountered
+            if ( zip_entry_name($zip_entry) === $zip_entry_starting_point ) {
+                $skip_file = false;
+            }
+
+            // continue to next zip_entry if the current one has been extracted in previous attempts
+            if ( $skip_file )
+                continue;
+            
+            $filename = $this->replace_forward_slash_with_directory_separator(zip_entry_name($zip_entry));
             // remove AASM_IMPORT_ZIP_FILE_NAME prefix in $filename
-            if (str_starts_with($filename, AASM_IMPORT_ZIP_FILE_NAME . DIRECTORY_SEPARATOR))
-            {
+            if (str_starts_with($filename, AASM_IMPORT_ZIP_FILE_NAME . DIRECTORY_SEPARATOR)) {
                 $filename = substr($filename, strlen(AASM_IMPORT_ZIP_FILE_NAME)+1);
             }
 
-            if (zip_entry_open($zip, $zip_entry, "r"))
-            {
-                // reset time counter to prevent timeout
-                set_time_limit(0);
+            // determine if this file is to be excluded
+            $should_exclude_file = false;
+            for ( $i = 0; $i < count( $files_to_exclude ); $i++ ) {
+                if ( str_starts_with( $filename , $this->replace_forward_slash_with_directory_separator( $files_to_exclude[ $i ] ) )) {
+                    $should_exclude_file = true;
+                    break;
+                }
+            }
 
+            // extract only wp-content files
+            if(!str_starts_with($filename, 'wp-content' . DIRECTORY_SEPARATOR))
+                $should_exclude_file = true;
+            
+            if ($should_exclude_file === false && zip_entry_open($zip, $zip_entry, "r")) {
                 $buf = zip_entry_read($zip_entry, zip_entry_filesize($zip_entry));
                 $path_file = $this->replace_forward_slash_with_directory_separator($destination_dir . $filename);
                 $new_dir = dirname($path_file);
-                
-                if (!str_ends_with($new_dir, DIRECTORY_SEPARATOR))
-                {
+
+                if (!str_ends_with($new_dir, DIRECTORY_SEPARATOR)) {
                     $new_dir .= DIRECTORY_SEPARATOR;
                 }
-
-                // determine if this file needs to be skipped
-                $should_exclude_file = false;
-                for ( $i = 0; $i < count( $files_to_exclude ); $i++ ) {
-                    if ( str_starts_with( $filename , $this->replace_forward_slash_with_directory_separator( $files_to_exclude[ $i ] ) )) {
-                        $should_exclude_file = true;
-                        break;
-                    }
+                
+                // Create Recursive Directory (if not exist)  
+                if (!file_exists($new_dir)) {
+                    mkdir($new_dir, 0777, true);
                 }
-
-                // extract only wp-content files
-                if(!str_starts_with($filename, 'wp-content' . DIRECTORY_SEPARATOR))
-                    $should_exclude_file = true;
-
-                if ($should_exclude_file === false)
-                {
-                    // Create Recursive Directory (if not exist)  
-                    if (!file_exists($new_dir)) {
-                        mkdir($new_dir, 0777, true);
-                    }
-                    
-                    // write only files to new directory
-                    if ( !str_ends_with($path_file, DIRECTORY_SEPARATOR))
-                    {
-                        $fp = fopen($path_file, "w");
-                        fwrite($fp, $buf);
-                        fclose($fp);
-                    }
+                
+                // write only files to new directory
+                if ( !str_ends_with($path_file, DIRECTORY_SEPARATOR)) {
+                    $fp = fopen($path_file, "w");
+                    fwrite($fp, $buf);
+                    fclose($fp);
                 }
+                
                 zip_entry_close($zip_entry);            
             }
-            $count++;
         }
 
         zip_close($zip);
+
+        return array (
+            'completed' => $completed,
+            'last_zip_entry' => $last_zip_entry,
+        );
     }
 
     public function extract_database_files($dir_to_extract = AASM_DATABASE_RELATIVE_PATH_IN_ZIP, $destination_dir) {
@@ -159,4 +193,9 @@ class AASM_Zip_Extractor {
     public function replace_forward_slash_with_directory_separator ( $dir ) {
         return str_replace("/", DIRECTORY_SEPARATOR, $dir);
     }
+
+    public function escape_windows_directory_separator( $path ) {
+        return preg_replace( '/[\\\\]+/', '\\\\\\\\', $path );
+    }
+
 }

--- a/azure_app_service_migration/utils/class-zip_extractor.php
+++ b/azure_app_service_migration/utils/class-zip_extractor.php
@@ -2,16 +2,9 @@
 // TO DO: This file will be redundant and needs to be deleted once batch processing is implemented for import
 class AASM_Zip_Extractor {
     private $zip_path = null;
-    private $file_handle = null;
-    private $eof = null;
 
     public function __construct( $zip_file_name ) {
         $this->zip_path = $zip_file_name;
-        
-        /*// Open input zip file for reading
-        if ( ( $this->file_handle = @fopen( $zip_file_name, 'rb' ) ) === false ) {
-            throw new AASM_File_Not_Found_Exception( "File Not Found: Couldn't find file at " . $zip_file_name );
-        }*/
     }
     
     public function extract( $destination_dir, $files_to_exclude = [], $zip_start_index ) {
@@ -33,7 +26,6 @@ class AASM_Zip_Extractor {
         } catch ( Exception $ex ) {
             throw $ex;
         }
-        Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'finished reading zip file', true);
 
         // initialize completed flag
         $completed = true;
@@ -45,7 +37,6 @@ class AASM_Zip_Extractor {
         $last_zip_index = $zip_start_index;
 
         for ($i = $zip_start_index; $i<$zip_num_files; $i++) {
-            Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Reading zip file index: ' . strval($i), true);
             // break when timeout (20s) is reached
             if ( ( microtime( true ) - $start ) > 20 ) {
                 $last_zip_index = $i;
@@ -74,6 +65,7 @@ class AASM_Zip_Extractor {
             }
 
             if ($should_exclude_file === false) {
+                Azure_app_service_migration_Custom_Logger::logInfo(AASM_IMPORT_SERVICE_TYPE, 'Extractin file: ' . $filename, true);
                 $path_file = $this->replace_forward_slash_with_directory_separator($destination_dir);
                 if (str_starts_with($filename, AASM_DATABASE_RELATIVE_PATH_IN_ZIP)) {
                     $path_file = $this->replace_forward_slash_with_directory_separator(AASM_DATABASE_TEMP_DIR);


### PR DESCRIPTION
Wp-content import is modified to run in batches for 20 seconds each before making an http request to create a new session that resumes execution.